### PR TITLE
Added missing Titles to Application Classes

### DIFF
--- a/wsps/export/0_pages.info
+++ b/wsps/export/0_pages.info
@@ -1,1 +1,1 @@
-{"filename":"0_pages","pagetitle":"0_Pages","ns":0,"username":"Import script","changed":"23-11-2021 07:39:43","pageid":84,"slots":"main,csp-base-props,csp-class-props","models":"wikitext,wikitext,wikitext","isFile":false,"description":"","tags":"Open CSP"}
+{"filename":"0_pages","pagetitle":"0_Pages","ns":0,"username":"Open CSP installation script","changed":"23-11-2021 07:39:43","pageid":93,"slots":"main,csp-base-props,csp-class-props","models":"wikitext,wikitext,wikitext","isFile":false,"description":"","tags":"Open CSP"}

--- a/wsps/export/0_search.info
+++ b/wsps/export/0_search.info
@@ -1,1 +1,1 @@
-{"filename":"0_search","pagetitle":"0_Search","ns":0,"username":"Admin","changed":"08-04-2022 13:33:33","pageid":61,"slots":"main,csp-base-props,csp-class-props","models":"wikitext,wikitext,wikitext","isFile":false,"description":"","tags":"Open CSP"}
+{"filename":"0_search","pagetitle":"0_Search","ns":0,"username":"Open CSP installation script","changed":"08-04-2022 13:33:33","pageid":62,"slots":"main,csp-base-props,csp-class-props","models":"wikitext,wikitext,wikitext","isFile":false,"description":"","tags":"Open CSP"}

--- a/wsps/export/0_search_slot_main.wiki
+++ b/wsps/export/0_search_slot_main.wiki
@@ -1,5 +1,5 @@
 __NOTOC__{{#ifsysop: {{CSP alert}} }}{{#WikiSearchConfig:
-|base query=[[Class::!Wiki]] [[Class::!Application page]]
+|base query=[[Class::!Wiki]] [[Class::!Application page]] [[Class::!Class definition]]
 |post filter properties=Class, Tags
 |search term properties=Title,Parsed text
 |aggregation size=50

--- a/wsps/export/102_description.info
+++ b/wsps/export/102_description.info
@@ -1,1 +1,1 @@
-{"filename":"102_description","pagetitle":"102_Description","ns":102,"username":"Admin","changed":"24-08-2023 11:37:26","pageid":144,"slots":"main","models":"wikitext","isFile":false,"description":"","tags":"Open CSP"}
+{"filename":"102_description","pagetitle":"102_Description","ns":102,"username":"Open CSP installation script","changed":"24-08-2023 11:37:26","pageid":50,"slots":"main,csp-base-props,csp-class-props","models":"wikitext,wikitext,wikitext","isFile":false,"description":"","tags":"Open CSP"}

--- a/wsps/export/102_description_slot_csp-base-props.wiki
+++ b/wsps/export/102_description_slot_csp-base-props.wiki
@@ -1,0 +1,3 @@
+{{Base properties
+|Class=Application page
+}}

--- a/wsps/export/102_description_slot_csp-class-props.wiki
+++ b/wsps/export/102_description_slot_csp-class-props.wiki
@@ -1,0 +1,2 @@
+{{Csp class properties
+}}

--- a/wsps/export/10_class_definition_properties.info
+++ b/wsps/export/10_class_definition_properties.info
@@ -1,1 +1,1 @@
-{"filename":"10_class_definition_properties","pagetitle":"10_Class definition properties","ns":10,"username":"Import script","changed":"24-10-2022 20:42:05","pageid":23,"slots":"main","models":"wikitext","isFile":false,"description":"","tags":"Open CSP"}
+{"filename":"10_class_definition_properties","pagetitle":"10_Class definition properties","ns":10,"username":"Open CSP installation script","changed":"24-10-2022 20:42:05","pageid":53,"slots":"main,csp-base-props,csp-class-props","models":"wikitext,wikitext,wikitext","isFile":false,"description":"","tags":"Open CSP"}

--- a/wsps/export/10_class_definition_properties_slot_csp-base-props.wiki
+++ b/wsps/export/10_class_definition_properties_slot_csp-base-props.wiki
@@ -1,0 +1,3 @@
+{{Base properties
+|Class=Application page
+}}

--- a/wsps/export/10_class_definition_properties_slot_csp-class-props.wiki
+++ b/wsps/export/10_class_definition_properties_slot_csp-class-props.wiki
@@ -1,0 +1,2 @@
+{{Csp class properties
+}}

--- a/wsps/export/10_class_definition_sidebar.info
+++ b/wsps/export/10_class_definition_sidebar.info
@@ -1,1 +1,1 @@
-{"filename":"10_class_definition_sidebar","pagetitle":"10_Class definition sidebar","ns":10,"username":"Admin","changed":"24-10-2022 20:41:56","pageid":24,"slots":"main","models":"wikitext","isFile":false,"description":"","tags":"Open CSP"}
+{"filename":"10_class_definition_sidebar","pagetitle":"10_Class definition sidebar","ns":10,"username":"Open CSP installation script","changed":"24-10-2022 20:41:56","pageid":54,"slots":"main,csp-base-props,csp-class-props","models":"wikitext,wikitext,wikitext","isFile":false,"description":"","tags":"Open CSP"}

--- a/wsps/export/10_class_definition_sidebar_slot_csp-base-props.wiki
+++ b/wsps/export/10_class_definition_sidebar_slot_csp-base-props.wiki
@@ -1,0 +1,3 @@
+{{Base properties
+|Class=Application page
+}}

--- a/wsps/export/10_class_definition_sidebar_slot_csp-class-props.wiki
+++ b/wsps/export/10_class_definition_sidebar_slot_csp-class-props.wiki
@@ -1,0 +1,2 @@
+{{Csp class properties
+}}

--- a/wsps/export/10_class_definitions.info
+++ b/wsps/export/10_class_definitions.info
@@ -1,1 +1,1 @@
-{"filename":"10_class_definitions","pagetitle":"10_Class definitions","ns":10,"username":"Admin","changed":"24-10-2022 20:43:16","pageid":19,"slots":"main","models":"wikitext","isFile":false,"description":"","tags":"Open CSP"}
+{"filename":"10_class_definitions","pagetitle":"10_Class definitions","ns":10,"username":"Open CSP installation script","changed":"24-10-2022 20:43:16","pageid":51,"slots":"main,csp-base-props,csp-class-props","models":"wikitext,wikitext,wikitext","isFile":false,"description":"","tags":"Open CSP"}

--- a/wsps/export/10_class_definitions_slot_csp-base-props.wiki
+++ b/wsps/export/10_class_definitions_slot_csp-base-props.wiki
@@ -1,0 +1,3 @@
+{{Base properties
+|Class=Application page
+}}

--- a/wsps/export/10_class_definitions_slot_csp-class-props.wiki
+++ b/wsps/export/10_class_definitions_slot_csp-class-props.wiki
@@ -1,0 +1,2 @@
+{{Csp class properties
+}}

--- a/wsps/export/4_class_definitions.info
+++ b/wsps/export/4_class_definitions.info
@@ -1,1 +1,1 @@
-{"filename":"4_class_definitions","pagetitle":"4_Class-definitions","ns":4,"username":"Admin","changed":"27-10-2023 14:10:35","pageid":93,"slots":"main","models":"wikitext","isFile":false,"description":"","tags":"Open CSP","changes":"27-10-2023 14:10:42"}
+{"filename":"4_class_definitions","pagetitle":"4_Class-definitions","ns":4,"username":"Open CSP installation script","changed":"27-10-2023 14:10:35","pageid":12,"slots":"main,csp-base-props,csp-class-props","models":"wikitext,wikitext,wikitext","isFile":false,"description":"","tags":"Open CSP"}

--- a/wsps/export/4_class_definitions_slot_csp-base-props.wiki
+++ b/wsps/export/4_class_definitions_slot_csp-base-props.wiki
@@ -1,0 +1,3 @@
+{{Base properties
+|Class=Application page
+}}

--- a/wsps/export/4_class_definitions_slot_csp-class-props.wiki
+++ b/wsps/export/4_class_definitions_slot_csp-class-props.wiki
@@ -1,0 +1,2 @@
+{{Csp class properties
+}}

--- a/wsps/export/4_wiki_pages.info
+++ b/wsps/export/4_wiki_pages.info
@@ -1,1 +1,1 @@
-{"filename":"4_wiki_pages","pagetitle":"4_Wiki pages","ns":4,"username":"Admin","changed":"23-11-2021 07:39:48","pageid":83,"slots":"main","models":"wikitext","isFile":false,"description":"","tags":"Open CSP"}
+{"filename":"4_wiki_pages","pagetitle":"4_Wiki pages","ns":4,"username":"Open CSP installation script","changed":"23-11-2021 07:39:48","pageid":92,"slots":"main,csp-base-props,csp-class-props","models":"wikitext,wikitext,wikitext","isFile":false,"description":"","tags":"Open CSP"}

--- a/wsps/export/4_wiki_pages_slot_csp-base-props.wiki
+++ b/wsps/export/4_wiki_pages_slot_csp-base-props.wiki
@@ -1,0 +1,3 @@
+{{Base properties
+|Class=Application page
+}}

--- a/wsps/export/4_wiki_pages_slot_csp-class-props.wiki
+++ b/wsps/export/4_wiki_pages_slot_csp-class-props.wiki
@@ -1,0 +1,2 @@
+{{Csp class properties
+}}


### PR DESCRIPTION
Some application pages were not classed as such. Also the default search showed Definitions classes, altered search to now show them.